### PR TITLE
Accept input from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ DESCRIPTION
        JSON format it will be converted to NDJSON. The result is printed to
        standard output.
 
+ARGUMENTS
+       FILE (required)
+           FILE must either be a file on your computer, or it must be '-' to
+           take input from stdin
+
 OPTIONS
        --help[=FMT] (default=auto)
            Show this help in format FMT. The value FMT must be one of `auto',

--- a/executable/ReNdjsonApp.re
+++ b/executable/ReNdjsonApp.re
@@ -16,9 +16,25 @@ let unknownFileType = (flagType, file) =>
   )
   |> print_endline;
 
+/** Custom converter to accept '-' as valid filename (for stdin) */
+let stdin_or_non_dir_file = {
+  let (parse as arg_parse, pp_print) = Arg.non_dir_file;
+
+  let parse = s =>
+    if (s == "-") {
+      `Ok(s);
+    } else {
+      arg_parse(s);
+    };
+
+  (parse, pp_print);
+};
+
 let file =
   Arg.(
-    required & pos(0, some(non_dir_file), None) & info([], ~docv="FILE")
+    required
+    & pos(0, some(stdin_or_non_dir_file), None)
+    & info([], ~docv="FILE")
   );
 
 let convertFlag = {

--- a/executable/ReNdjsonApp.re
+++ b/executable/ReNdjsonApp.re
@@ -9,9 +9,9 @@ type flagType =
 let unknownFileType = (flagType, file) =>
   (
     switch (flagType) {
-    | Unspecified => ReNdjson.Util.convertInput(Unknown(file))
-    | Json => ReNdjson.Util.convertInput(JsonToNdjson(file))
-    | Ndjson => ReNdjson.Util.convertInput(NdjsonToJson(file))
+    | Unspecified => ReNdjson.Util.convertInput(Unknown, file)
+    | Json => ReNdjson.Util.convertInput(JsonToNdjson, file)
+    | Ndjson => ReNdjson.Util.convertInput(NdjsonToJson, file)
     }
   )
   |> print_endline;

--- a/executable/ReNdjsonApp.re
+++ b/executable/ReNdjsonApp.re
@@ -30,12 +30,16 @@ let stdin_or_non_dir_file = {
   (parse, pp_print);
 };
 
-let file =
+let file = {
+  let doc =
+    "$(i,FILE) must either be a file on your computer, or it must be "
+    ++ "'-' to take input from stdin";
   Arg.(
     required
     & pos(0, some(stdin_or_non_dir_file), None)
-    & info([], ~docv="FILE")
+    & info([], ~doc, ~docv="FILE")
   );
+};
 
 let convertFlag = {
   let doc = "Convert from JSON file";

--- a/library/NdjsonUtil.re
+++ b/library/NdjsonUtil.re
@@ -43,6 +43,5 @@ let ndjsonToJson = (~firstLine=?, ndjsonChannel) => {
       }
     };
 
-  Pervasives.close_in(ndjsonChannel);
   json |> toJsonArrayFromList |> Yojson.Basic.pretty_to_string;
 };

--- a/library/Util.re
+++ b/library/Util.re
@@ -1,40 +1,74 @@
 type convertMethod =
-  | NdjsonToJson(string)
-  | JsonToNdjson(string)
-  | Unknown(string);
+  | NdjsonToJson
+  | JsonToNdjson
+  | Unknown;
 
-let convertNdjsonToJson = inputFile => {
-  let file = Pervasives.open_in(inputFile);
-  NdjsonUtil.ndjsonToJson(file);
+let convertNdjsonToJson = input => {
+  NdjsonUtil.ndjsonToJson(input);
 };
 
-let convertJsonToNdjson = inputFile => {
-  let json = Yojson.Basic.from_file(inputFile);
+let read_in_channel = (~startValue=?, input) => {
+  let rec read_in_channel' = stringified_input => {
+    switch (Pervasives.input_line(input)) {
+    | line => read_in_channel'(stringified_input ++ line)
+    | exception End_of_file => stringified_input
+    };
+  };
+
+  switch (startValue) {
+  | Some(value) => read_in_channel'(value)
+  | None => read_in_channel'("")
+  };
+};
+
+let convertJsonToNdjson = (~firstLineJson=?, ~firstLine=?, input) => {
+  let json =
+    switch (firstLine) {
+    | Some(firstLine) =>
+      input
+      |> read_in_channel(~startValue=firstLine)
+      |> Yojson.Basic.from_string
+    | None =>
+      switch (firstLineJson) {
+      | Some(json) => json
+      | None => Yojson.Basic.from_channel(input)
+      }
+    };
 
   let listOfObjects = Yojson.Basic.Util.to_list(json);
 
   listOfObjects |> List.map(Yojson.Basic.to_string) |> String.concat("\n");
 };
 
-let convertUnknown = inputFile => {
-  let file = Pervasives.open_in(inputFile);
-
-  let firstLine = Pervasives.input_line(file);
+let convertUnknown = input => {
+  let firstLine = Pervasives.input_line(input);
 
   switch (Yojson.Basic.from_string(firstLine)) {
   | exception (Yojson.Json_error(_msg)) =>
-    Pervasives.close_in(file);
-    convertJsonToNdjson(inputFile);
-  | `Assoc(_) as ndjson => NdjsonUtil.ndjsonToJson(~firstLine=ndjson, file)
-  | json =>
-    Pervasives.close_in(file);
-    convertJsonToNdjson(inputFile);
+    convertJsonToNdjson(~firstLine, input)
+  | `Assoc(_) as ndjson => NdjsonUtil.ndjsonToJson(~firstLine=ndjson, input)
+  | json => convertJsonToNdjson(~firstLineJson=json, input)
   };
 };
 
-let convertInput = method =>
-  switch (method) {
-  | NdjsonToJson(file) => convertNdjsonToJson(file)
-  | JsonToNdjson(file) => convertJsonToNdjson(file)
-  | Unknown(file) => convertUnknown(file)
+let convertInput = (inputType, file) => {
+  let input =
+    if (file == "-") {
+      Pervasives.stdin;
+    } else {
+      Pervasives.open_in(file);
+    };
+
+  let convertedInput =
+    switch (inputType) {
+    | NdjsonToJson => convertNdjsonToJson(input)
+    | JsonToNdjson => convertJsonToNdjson(input)
+    | Unknown => convertUnknown(input)
+    };
+
+  if (file != "-") {
+    Pervasives.close_in(input);
   };
+
+  convertedInput;
+};


### PR DESCRIPTION
In addition to accepting input from filename, it will now acceept from "filename" `-` as well, which means stdin.

E.g. `cat test.json | ndjson -j -` will convert `test.json` via stdin to `ndjson` printed to stdout.

Closes #1 